### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/infra/infra.yaml
+++ b/infra/infra.yaml
@@ -159,7 +159,7 @@ Resources:
       Role:
         !GetAtt IamRoleLambdaFunction.Arn
       Code: ../code
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '30'
       VpcConfig:
         SecurityGroupIds:

--- a/package.yaml
+++ b/package.yaml
@@ -175,7 +175,7 @@ Resources:
       Code:
         S3Bucket: lexlabs3bucketmgmtapps
         S3Key: f4a779b4953357ca1517a6a0e76994f4
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: '30'
       VpcConfig:
         SecurityGroupIds:


### PR DESCRIPTION
CloudFormation templates in aws-codepipeline-bitbucket-integration have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.