### PR TITLE
fix: make sanitizeS3KeyComponent injective to prevent branch name colisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,6 @@ temp/
 **/test-reports/
 **/test-results/
 
+
+# Kiro specs
+.kiro/

--- a/app/bitbucket-integration-v2/repository-processor/lib/uploader.js
+++ b/app/bitbucket-integration-v2/repository-processor/lib/uploader.js
@@ -46,11 +46,11 @@ export class S3Uploader {
      * @returns {string} Sanitized component
      */
     sanitizeS3KeyComponent(component) {
-        return component
-            .replace(/[^a-zA-Z0-9\-_.]/g, '-') // Replace invalid chars with dash
-            .replace(/-+/g, '-') // Replace multiple dashes with single dash
-            .replace(/^-|-$/g, '') // Remove leading/trailing dashes
-            .toLowerCase();
+        const lower = component.toLowerCase();
+        return lower.replace(/[^a-zA-Z0-9\-_.]/g, (char) => {
+            const hex = char.charCodeAt(0).toString(16).padStart(2, '0');
+            return '~' + hex;
+        });
     }
 
     /**

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,11 @@ export default {
     '!app/**/node_modules/**'
   ],
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
-  testTimeout: 30000
+  testTimeout: 30000,
+  moduleNameMapper: {
+    '^/opt/nodejs/lib/logger\\.js$': '<rootDir>/tests/mocks/lambda-layer/logger.js',
+    '^/opt/nodejs/lib/util\\.js$': '<rootDir>/tests/mocks/lambda-layer/util.js',
+    '^@aws-sdk/client-s3$': '<rootDir>/tests/mocks/lambda-layer/aws-s3.js',
+    '^@aws-sdk/lib-storage$': '<rootDir>/tests/mocks/lambda-layer/aws-s3-storage.js'
+  }
 };

--- a/tests/mocks/lambda-layer/aws-s3-storage.js
+++ b/tests/mocks/lambda-layer/aws-s3-storage.js
@@ -1,0 +1,1 @@
+export class Upload {}

--- a/tests/mocks/lambda-layer/aws-s3.js
+++ b/tests/mocks/lambda-layer/aws-s3.js
@@ -1,0 +1,2 @@
+export class S3Client {}
+export class HeadObjectCommand {}

--- a/tests/mocks/lambda-layer/logger.js
+++ b/tests/mocks/lambda-layer/logger.js
@@ -1,0 +1,6 @@
+export const logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};

--- a/tests/mocks/lambda-layer/util.js
+++ b/tests/mocks/lambda-layer/util.js
@@ -1,0 +1,3 @@
+export const sharedUtil = {
+  retryWithBackoff: async (fn) => fn(),
+};

--- a/tests/unit/repository-processor/sanitize-bug-condition.test.js
+++ b/tests/unit/repository-processor/sanitize-bug-condition.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { S3Uploader } from '../../../app/bitbucket-integration-v2/repository-processor/lib/uploader.js';
+
+/**
+ * Bug Condition Exploration Test — Branch Name Collision via Non-Injective Sanitization
+ *
+ * Validates: Requirements 1.1, 1.2, 1.3, 2.1, 2.2, 2.3
+ *
+ * These tests assert that sanitizeS3KeyComponent is injective (one-to-one):
+ * distinct branch names must produce distinct sanitized outputs.
+ *
+ * On UNFIXED code these tests are EXPECTED TO FAIL, confirming the bug exists.
+ */
+describe('Bug Condition: sanitizeS3KeyComponent injectivity', () => {
+  let uploader;
+
+  beforeAll(() => {
+    uploader = new S3Uploader();
+  });
+
+  it('should produce distinct outputs for "feature/foo" vs "feature-foo" (slash replaced by dash)', () => {
+    const a = uploader.sanitizeS3KeyComponent('feature/foo');
+    const b = uploader.sanitizeS3KeyComponent('feature-foo');
+    expect(a).not.toBe(b);
+  });
+
+  it('should produce distinct outputs for "release@1.0" vs "release-1.0" (at-sign replaced by dash)', () => {
+    const a = uploader.sanitizeS3KeyComponent('release@1.0');
+    const b = uploader.sanitizeS3KeyComponent('release-1.0');
+    expect(a).not.toBe(b);
+  });
+
+  it('should produce distinct outputs for "a/b/c" vs "a-b-c" (multi-slash replaced by dashes)', () => {
+    const a = uploader.sanitizeS3KeyComponent('a/b/c');
+    const b = uploader.sanitizeS3KeyComponent('a-b-c');
+    expect(a).not.toBe(b);
+  });
+
+  it('should produce distinct outputs for "a//b" vs "a/b" (double-slash collapsed to single dash)', () => {
+    const a = uploader.sanitizeS3KeyComponent('a//b');
+    const b = uploader.sanitizeS3KeyComponent('a/b');
+    expect(a).not.toBe(b);
+  });
+});

--- a/tests/unit/repository-processor/sanitize-preservation.test.js
+++ b/tests/unit/repository-processor/sanitize-preservation.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { S3Uploader } from '../../../app/bitbucket-integration-v2/repository-processor/lib/uploader.js';
+
+/**
+ * Preservation Property Test — Safe Branch Names Unchanged
+ *
+ * Validates: Requirements 3.1, 3.2
+ *
+ * For branch names containing only safe characters [a-zA-Z0-9\-_.],
+ * the output must equal input.toLowerCase().
+ * This must hold on both unfixed and fixed code.
+ */
+describe('Preservation: safe branch names unchanged', () => {
+  let uploader;
+
+  beforeAll(() => {
+    uploader = new S3Uploader();
+  });
+
+  it('should preserve "main" as "main"', () => {
+    expect(uploader.sanitizeS3KeyComponent('main')).toBe('main');
+  });
+
+  it('should preserve "release-1.0.0" as "release-1.0.0"', () => {
+    expect(uploader.sanitizeS3KeyComponent('release-1.0.0')).toBe('release-1.0.0');
+  });
+
+  it('should preserve "v1.2.3" as "v1.2.3"', () => {
+    expect(uploader.sanitizeS3KeyComponent('v1.2.3')).toBe('v1.2.3');
+  });
+
+  it('should preserve "feature_flag" as "feature_flag"', () => {
+    expect(uploader.sanitizeS3KeyComponent('feature_flag')).toBe('feature_flag');
+  });
+
+  it('should normalize case: "DEVELOP" becomes "develop"', () => {
+    expect(uploader.sanitizeS3KeyComponent('DEVELOP')).toBe('develop');
+  });
+
+  it('should produce correct generateS3Key format for safe inputs', () => {
+    const key = uploader.generateS3Key('MyProject', 'my-repo', 'main', 'corr-1');
+    expect(key).toBe('repositories/myproject/my-repo/main/source.zip');
+  });
+});


### PR DESCRIPTION
Replace lossy dash-substitution with tilde-hex encoding for non-safe characters in S3 key components. This prevents distinct branch names (e.g. feature/foo vs feature-foo) from mapping to the same S3 key, closing a cross-branch source code poisoning vector (H1-3627488).

Safe-character-only branch names produce identical output to before.

Changes:
- uploader.js: replace regex substitution with tilde-hex encoding
- jest.config.js: add moduleNameMapper for Lambda layer mocks
- Add Lambda layer mock files for unit tests
- Add bug condition and preservation property tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
